### PR TITLE
docs: CLAUDE.md を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# Claude 開発ガイドライン
+
+## リポジトリについて
+
+このリポジトリは [pimalaya/himalaya](https://github.com/pimalaya/himalaya) の**Forkリポジトリ**です。
+
+Himalayaは、Rustで書かれたCLIベースのメールクライアントです。IMAP、Maildir、Notmuchなど複数のバックエンドをサポートしています。
+
+## 重要な注意事項
+
+### Issue・PRの作成ルール
+
+- **IssueやPRはこのForkリポジトリ（delamain-corp/himalaya）内で完結させてください**
+- **Fork元リポジトリ（pimalaya/himalaya）へのIssue作成やPR送信は禁止です**
+- PRのベースブランチは必ずこのリポジトリ内のブランチ（例: `master`）を指定してください
+
+### ブランチ運用
+
+- デフォルトブランチ: `master`
+- 機能追加ブランチ: `feature/<作業名>`
+- バグ修正ブランチ: `fix/<作業名>`
+
+## 開発環境
+
+### 必要なツール
+
+- Rust（toolchainバージョンは `rust-toolchain.toml` を参照）
+- Cargo
+
+### ビルド
+
+```bash
+cargo build --release
+```
+
+### テスト
+
+```bash
+cargo test
+```
+
+### 機能フラグ
+
+このプロジェクトはCargoのfeature flagsを使用しています。主な機能:
+
+- `imap` - IMAPバックエンド
+- `maildir` - Maildirバックエンド
+- `notmuch` - Notmuchバックエンド
+- `smtp` - SMTPバックエンド
+- `keyring` - システムキーリング連携
+- `oauth2` - OAuth 2.0認証
+- `pgp-*` - PGP暗号化機能
+
+## コミットメッセージ
+
+Conventional Commits形式を使用してください:
+
+```
+feat: 新機能の追加
+fix: バグ修正
+docs: ドキュメントの変更
+refactor: リファクタリング
+test: テストの追加・修正
+chore: その他の変更
+```
+
+## 設定ファイル
+
+- `config.sample.toml` - 設定ファイルのサンプル
+- `Cargo.toml` - プロジェクト設定とデフォルト機能の定義


### PR DESCRIPTION
## Summary
- Claude Code向けの開発ガイドライン（CLAUDE.md）を追加
- Forkリポジトリとしての運用ルールを明記（Issue/PRの作成先制限）
- 基本的な開発環境情報とコミット規約を記載

## 変更内容
- `CLAUDE.md`: 新規作成

## 確認済み
- [x] ファイルが正常に作成されていること
- [x] 日本語で記載されていること
- [x] Forkリポジトリのルールが明記されていること

## 未確認
- CIが設定されている場合のビルド結果

---
Generated with [Claude Code](https://claude.com/claude-code)