### PR TITLE
feat: message readコマンドでJSONモード時に構造化された出力を実現

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,6 +1816,7 @@ dependencies = [
  "clap_mangen",
  "color-eyre",
  "email-lib",
+ "mail-parser",
  "mml-lib",
  "once_cell",
  "open",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ clap_complete = "4.4"
 clap_mangen = "0.2"
 color-eyre = "0.6"
 email-lib = { version = "0.26", default-features = false, features = ["tokio-rustls", "derive", "thread"] }
+mail-parser = "0.9"
 mml-lib = { version = "1", default-features = false, features = ["compiler", "interpreter", "derive"]  }
 once_cell = "1.16"
 open = "5.3"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.82.0"
+channel = "stable"
 profile = "default"
 components = ["rust-src", "rust-analyzer"]

--- a/src/email/message/command/read.rs
+++ b/src/email/message/command/read.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 use clap::Parser;
 use color_eyre::Result;
@@ -7,6 +7,7 @@ use pimalaya_tui::{
     himalaya::backend::BackendBuilder,
     terminal::{cli::printer::Printer, config::TomlConfig as _},
 };
+use serde::Serialize;
 use tracing::info;
 
 #[allow(unused)]
@@ -14,6 +15,54 @@ use crate::{
     account::arg::name::AccountNameFlag, config::TomlConfig, envelope::arg::ids::EnvelopeIdsArgs,
     folder::arg::name::FolderNameOptionalFlag,
 };
+
+/// Represents a structured message for JSON output.
+#[derive(Clone, Debug, Serialize)]
+pub struct StructuredMessage {
+    /// The envelope ID of the message.
+    pub id: String,
+    /// The message headers (From, To, Subject, Date, etc.).
+    pub headers: MessageHeaders,
+    /// The plain text body of the message.
+    pub body: String,
+}
+
+/// Represents the headers of a message.
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct MessageHeaders {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bcc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub in_reply_to: Option<String>,
+}
+
+/// A collection of structured messages.
+#[derive(Clone, Debug, Serialize)]
+pub struct StructuredMessages(Vec<StructuredMessage>);
+
+impl fmt::Display for StructuredMessages {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut glue = "";
+        for msg in &self.0 {
+            write!(f, "{glue}")?;
+            write!(f, "{}", msg.body)?;
+            glue = "\n\n";
+        }
+        Ok(())
+    }
+}
 
 /// Read a human-friendly version of the message associated to the
 /// given envelope id(s).
@@ -90,12 +139,9 @@ impl MessageReadCommand {
             backend.get_messages(folder, ids).await
         }?;
 
-        let mut glue = "";
-        let mut bodies = String::default();
+        let mut structured_messages = Vec::new();
 
-        for email in emails.to_vec() {
-            bodies.push_str(glue);
-
+        for (idx, email) in emails.to_vec().iter().enumerate() {
             let tpl = email
                 .to_read_tpl(&account_config, |mut tpl| {
                     if self.no_headers {
@@ -107,11 +153,87 @@ impl MessageReadCommand {
                     tpl
                 })
                 .await?;
-            bodies.push_str(&tpl);
 
-            glue = "\n\n";
+            // Extract headers from the parsed email
+            let parsed = email.parsed();
+            let headers = if let Ok(parsed) = parsed {
+                MessageHeaders {
+                    from: parsed.from().map(format_address),
+                    to: parsed.to().map(format_address),
+                    cc: parsed.cc().map(format_address),
+                    bcc: parsed.bcc().map(format_address),
+                    subject: parsed.subject().map(|s| s.to_string()),
+                    date: parsed.date().map(|d| d.to_rfc3339()),
+                    message_id: parsed.message_id().map(|s| s.to_string()),
+                    in_reply_to: parsed.in_reply_to().as_text_list()
+                        .and_then(|ids| ids.first().map(|s| s.to_string())),
+                }
+            } else {
+                MessageHeaders::default()
+            };
+
+            // Extract body from template (the body part after headers)
+            let body = extract_body_from_template(&tpl);
+
+            // Use the envelope ID if available, otherwise use index
+            let id = ids.get(idx).map(|s| s.to_string()).unwrap_or_else(|| idx.to_string());
+
+            structured_messages.push(StructuredMessage {
+                id,
+                headers,
+                body,
+            });
         }
 
-        printer.out(bodies)
+        printer.out(StructuredMessages(structured_messages))
+    }
+}
+
+/// Formats an Address to a human-readable string.
+fn format_address(addr: &mail_parser::Address) -> String {
+    match addr {
+        mail_parser::Address::List(addrs) => {
+            addrs
+                .iter()
+                .filter_map(|a| {
+                    match (&a.name, &a.address) {
+                        (Some(name), Some(email)) => Some(format!("{} <{}>", name, email)),
+                        (None, Some(email)) => Some(email.to_string()),
+                        (Some(name), None) => Some(name.to_string()),
+                        (None, None) => None,
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
+        }
+        mail_parser::Address::Group(groups) => {
+            groups
+                .iter()
+                .map(|g| {
+                    let name = g.name.as_deref().unwrap_or("");
+                    let members = g
+                        .addresses
+                        .iter()
+                        .filter_map(|a| a.address.as_ref().map(|s| s.to_string()))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!("{}: {};", name, members)
+                })
+                .collect::<Vec<_>>()
+                .join(" ")
+        }
+    }
+}
+
+/// Extracts the body from a template string (after the header section).
+fn extract_body_from_template(tpl: &str) -> String {
+    // The template format has headers followed by an empty line, then the body
+    if let Some(pos) = tpl.find("\n\n") {
+        tpl[pos + 2..].to_string()
+    } else if let Some(pos) = tpl.find("\r\n\r\n") {
+        tpl[pos + 4..].to_string()
+    } else {
+        // If no header separator found, return the whole template as body
+        tpl.to_string()
     }
 }


### PR DESCRIPTION
## Summary

- `message read` コマンドの JSON 出力を改善し、メッセージを構造化して出力するようにしました
- `StructuredMessage`, `MessageHeaders`, `StructuredMessages` 構造体を追加
- 複数メールをリクエストした場合は配列として返します
- ヘッダー情報（From, To, Cc, Bcc, Subject, Date, Message-ID, In-Reply-To）を構造化して出力

### 変更内容

1. **src/email/message/command/read.rs**
   - `StructuredMessage` 構造体: メッセージID、ヘッダー、本文を持つ構造体
   - `MessageHeaders` 構造体: From, To, Cc, Bcc, Subject, Date, Message-ID, In-Reply-To を持つ
   - `StructuredMessages` 構造体: メッセージ配列をラップ
   - `format_address()`: メールアドレスを人間が読みやすい形式にフォーマット
   - `extract_body_from_template()`: テンプレートからボディ部分を抽出

2. **Cargo.toml**
   - `mail-parser = "0.9"` を依存関係に追加

3. **rust-toolchain.toml**
   - channel を `1.82.0` から `stable` に変更（依存ライブラリが edition2024 を使用しているため必要）

### JSON出力例

```json
[
  {
    "id": "1",
    "headers": {
      "from": "sender@example.com",
      "to": "recipient@example.com",
      "subject": "Test Email",
      "date": "2026-01-23T12:00:00+09:00",
      "message_id": "<msg-id@example.com>"
    },
    "body": "Hello, this is a test email."
  }
]
```

## Test plan

- [x] `cargo build --release` が成功することを確認
- [x] `cargo test` が成功することを確認
- [ ] 実際のメールサーバーに接続して `himalaya -o json message read <id>` の出力を確認（未実施: 実メールサーバーへの接続設定が必要）

Closes #3

Generated with [Claude Code](https://claude.ai/claude-code)